### PR TITLE
Update next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
   webpack: function (config, options) {
     config.experiments = {
       asyncWebAssembly: true,
+      layers: true,
     };
     return config;
   },


### PR DESCRIPTION
Layers has to be enabled in order for the npm run build to work.

Here's the terminal error: 
Build error occurred
Error: 'entryOptions.layer' is only allowed when 'experiments.layers' is enabled